### PR TITLE
Add package.json for MIP compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "urls": [
+    ["adc1_cal.py", "github:matthias-bs/MicroPython-ADC_Cal/adc1_cal.py"]
+  ],
+  "version": "1.0.0",
+  "deps": []
+}


### PR DESCRIPTION
## Summary
- Add package.json file to make this library installable via the MicroPython Package Manager (MIP)
- Enables installation with `mip install github:matthias-bs/MicroPython-ADC_Cal`

## Test plan
- Verify that the package can be installed using MIP

🤖 Generated with [Claude Code](https://claude.ai/code)